### PR TITLE
Support TLS 1.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,4 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
-before:
-  hooks:
-    # You may remove this if you don't use go modules.
-    - go mod download
+# See documentation at http://goreleaser.com
 builds:
 - env:
   - CGO_ENABLED=0

--- a/server.go
+++ b/server.go
@@ -179,7 +179,7 @@ func (srv *Server) serveInsecure(l net.Listener) (err error) {
 
 func (srv *Server) serveTLS(l net.Listener) (err error) {
 	config := &tls.Config{
-		MinVersion:         tls.VersionTLS13,
+		MinVersion:         tls.VersionTLS12,
 		ClientAuth:         tls.RequestClientCert,
 		InsecureSkipVerify: true,
 		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {


### PR DESCRIPTION
As per #6, some clients can't support TLS 1.3.

To support a broader range of clients, I'm moving the minimum TLS version down to 1.2. If anyone is concerned about this change, and wishes to keep to a minimum of 1.3, let me know and I'll consider a flag for the config setting - I'm trying to keep the config as minimal as possible to keep complexity down.